### PR TITLE
Add docs and Docker image for dynamic SSL certificates with Ceryx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ production.yml
 dev.yml
 data
 docker-compose.yaml
+.stolos

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ keep developing this as an Open Source project. Feel free to make suggestions
 in the [issues section](https://github.com/sourcelair/ceryx/issues) in Github
 or open o pull request.
 
+## Dynamic SSL certificates
+
+You can read more information on how to configure Ceryx with Dynamic SSL certificates [here](docs/dynamic-ssl).
+
 ## License
 
 Ceryx is licensed under the "The MIT License (MIT)".

--- a/dynamic-ssl/Dockerfile
+++ b/dynamic-ssl/Dockerfile
@@ -1,0 +1,13 @@
+FROM sourcelair/ceryx-proxy:xenial
+MAINTAINER Antonis Kalipetis <akalipetis@gmail.com>
+
+RUN mkdir -p /etc/letsencrypt &&\
+    openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 \
+        -subj '/CN=sni-support-required-for-valid-ssl' \
+        -keyout /etc/ssl/resty-auto-ssl-fallback.key \
+        -out /etc/ssl/resty-auto-ssl-fallback.crt
+
+RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl
+
+COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+COPY ceryx.conf /usr/local/openresty/nginx/sites-enabled/ceryx.conf

--- a/dynamic-ssl/README.md
+++ b/dynamic-ssl/README.md
@@ -1,0 +1,30 @@
+# Setting up dynamic SSL certificates with Let's encrypt
+
+[Let's encrypt](https://letsencrypt.org/) is a free, automated, and open Certificate Authority.
+
+This means that we can generate such certificates dynamically, each time a new HTTPS domain hits Ceryx. To do so, we'll use the great `[lua-resty-auto-ssl](https://github.com/GUI/lua-resty-auto-ssl)` library.
+
+In order to make this work, your should use the `sourcelair/ceryx-proxy:dynamic-ssl` image flavor and define the following evnrironment variables:
+
+* `CERYX_SSL_PATTERN` - Ceryx will check against this pattern before authorizing a new certificate. This could be something like `^subdomain.example.com$` for an exact domain, or `example.com$` for more than one subdomain. Note that this will still allow things like `heyexample.com`, but it's probably not worth the ugliness.
+
+An example `docker-compose.yaml` file for this would be:
+
+```yaml
+version: '2'
+
+services:
+  proxy:
+    image: sourcelair/ceryx-proxy:dynamic-ssl
+    ports:
+      - 80:80
+      - 443:443
+    environment:
+      - CERYX_REDIS_HOST=redis
+      - CERYX_REDIS_PORT=6379
+      - CERYX_SSL_PATTERN=example.com$
+      - CERYX_FALLBACK=www.something.com
+    restart: always
+
+    ...
+```

--- a/dynamic-ssl/ceryx.conf
+++ b/dynamic-ssl/ceryx.conf
@@ -1,0 +1,77 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+map $http_x_forwarded_proto $proxy_set_x_forwarded_proto {
+    default $scheme;
+    'http'  http;
+    'https' https;
+}
+
+server {
+    listen 80;
+    listen 443 ssl;
+    default_type text/html;
+
+    ssl_certificate /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    ssl_certificate_by_lua_block {
+        auto_ssl:ssl_certificate()
+    }
+
+    location /.well-known/acme-challenge {
+        content_by_lua_block {
+            auto_ssl:challenge_server()
+        }
+    }
+
+    location / {
+        set $container_url "fallback";
+
+        # Lua files
+        access_by_lua_file lualib/router.lua;
+
+        # Proxy configuration
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP  $remote_addr;
+        proxy_set_header X-Forwarded-Proto $proxy_set_x_forwarded_proto;
+
+        # Upgrade headers
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_pass http://$container_url$request_uri;
+    }
+
+    error_page 502 @bad_gateway;
+    location @bad_gateway {
+        set $fallback_url "";
+
+        # Get fallback URL from environment
+        access_by_lua_block {
+            ngx.var.fallback_url = os.getenv("CERYX_FALLBACK")
+            if not ngx.var.fallback_url then ngx.var.fallback_url = "www.something.com" end
+        }
+
+        # Proxy configuration
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP  $remote_addr;
+        proxy_set_header X-Forwarded-Proto $proxy_set_x_forwarded_proto;
+
+        proxy_pass http://$fallback_url$request_uri;
+    }
+}
+
+# Internal server running on port 8999 for handling certificate tasks.
+server {
+    listen 127.0.0.1:8999;
+    location / {
+        content_by_lua_block {
+            auto_ssl:hook_server()
+        }
+    }
+}

--- a/dynamic-ssl/nginx.conf
+++ b/dynamic-ssl/nginx.conf
@@ -1,0 +1,70 @@
+user www-data www-data;
+worker_processes 1;
+pid /run/nginx.pid;
+
+env CERYX_REDIS_PREFIX;
+env CERYX_REDIS_HOST;
+env CERYX_REDIS_PORT;
+env CERYX_SSL_PATTERN;
+env CERYX_FALLBACK;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    # Basic Settings
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 30s 30s;
+    # Use the Docker internal DNS, pick your favorite if running outside of Docker
+    resolver 127.0.0.11;
+
+    # Logging
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
+
+    # Lua settings
+    lua_package_path "$prefix/lualib/?.lua;;";
+
+    lua_shared_dict ceryx 1m;
+    lua_shared_dict auto_ssl 1m;
+    lua_code_cache on;
+
+    # see https://github.com/openresty/lua-resty-core
+    init_by_lua_block  {
+        auto_ssl = (require "resty.auto-ssl").new()
+
+        -- Define a function to determine which SNI domains to automatically handle
+        -- and register new certificates for. Defaults to not allowing any domains,
+        -- so this must be configured.
+        auto_ssl:set("allow_domain", function(domain)
+            local ceryx_ssl_pattern = os.getenv("CERYX_SSL_PATTERN")
+            if not ceryx_ssl_pattern then ceryx_ssl_pattern = "" end
+            return string.match(domain, ceryx_ssl_pattern) ~= nil
+        end)
+
+        -- Set the resty-auto-ssl storage to Redis, using the CERYX_* env variables
+        local redis_host = os.getenv("CERYX_REDIS_HOST")
+        if not redis_host then redis_host = "127.0.0.1" end
+        local redis_port = os.getenv("CERYX_REDIS_PORT")
+        if not redis_port then redis_port = 6379 end
+        auto_ssl:set("storage_adapter", "resty.auto-ssl.storage_adapters.redis")
+        auto_ssl:set("redis", {
+            host = redis_host,
+            port = redis_port
+        })
+
+        auto_ssl:init()
+        require "resty.core"
+    }
+
+    init_worker_by_lua_block {
+        auto_ssl:init_worker()
+    }
+
+    # Includes
+    include mime.types;
+    include ../sites-enabled/*;
+}


### PR DESCRIPTION
Core configuration can be updated using environment variables, while more fine grained one cane be done by extending from the given Dockerfile.

Signed-off-by: Antonis Kalipetis <akalipetis@gmail.com>