### PR TITLE
Fix redirects in dynamic SSL

### DIFF
--- a/dynamic-ssl/ceryx.conf
+++ b/dynamic-ssl/ceryx.conf
@@ -42,6 +42,9 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
+        proxy_redirect ~^(http://[^:]+):\d+(/.+)$ $2;
+        proxy_redirect ~^(https://[^:]+):\d+(/.+)$ $2;
+        proxy_redirect / /;
 
         proxy_pass http://$container_url$request_uri;
     }


### PR DESCRIPTION
Add [`proxy_redirect`](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect) directive as used in the [typical (non-dynamic SSL) Ceryx scenario](https://github.com/sourcelair/ceryx/blob/3e7b2fb/proxy/nginx/sites-enabled/ceryx.conf#L34).