### PR TITLE
Fix LUA errors in dynamic SSL

### DIFF
--- a/dynamic-ssl/nginx.conf
+++ b/dynamic-ssl/nginx.conf
@@ -30,6 +30,7 @@ http {
 
     lua_shared_dict ceryx 1m;
     lua_shared_dict auto_ssl 1m;
+    lua_shared_dict auto_ssl_settings 64k;
     lua_code_cache on;
 
     # see https://github.com/openresty/lua-resty-core


### PR DESCRIPTION
This saves us from the following error:

```
proxy_1  | nginx: [error] [lua] init_master.lua:96: init_master(): auto-ssl: dict auto_ssl_settings could not be found. Please add it to your configuration: `lua_shared_dict auto_ssl_settings 64k;`
proxy_1  | 2017/07/11 18:28:34 [error] 1#1: init_by_lua error: ...esty/luajit/share/lua/5.1/resty/auto-ssl/init_master.lua:31: attempt to index field 'auto_ssl_settings' (a nil value)
proxy_1  | stack traceback:
proxy_1  | 	...esty/luajit/share/lua/5.1/resty/auto-ssl/init_master.lua:31: in function 'generate_hook_sever_secret'
proxy_1  | 	...esty/luajit/share/lua/5.1/resty/auto-ssl/init_master.lua:100: in function 'init_master'
proxy_1  | 	.../local/openresty/luajit/share/lua/5.1/resty/auto-ssl.lua:64: in function 'init'
proxy_1  | 	init_by_lua:24: in main chunk
proxy_1  | nginx: [error] init_by_lua error: ...esty/luajit/share/lua/5.1/resty/auto-ssl/init_master.lua:31: attempt to index field 'auto_ssl_settings' (a nil value)
proxy_1  | stack traceback:
proxy_1  | 	...esty/luajit/share/lua/5.1/resty/auto-ssl/init_master.lua:31: in function 'generate_hook_sever_secret'
proxy_1  | 	...esty/luajit/share/lua/5.1/resty/auto-ssl/init_master.lua:100: in function 'init_master'
proxy_1  | 	.../local/openresty/luajit/share/lua/5.1/resty/auto-ssl.lua:64: in function 'init'
proxy_1  | 	init_by_lua:24: in main chunk
```