### PR TITLE
Update lua-resty-auto-ssl to 0.11.1

### DIFF
--- a/dynamic-ssl/Dockerfile
+++ b/dynamic-ssl/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p /etc/letsencrypt &&\
         -keyout /etc/ssl/resty-auto-ssl-fallback.key \
         -out /etc/ssl/resty-auto-ssl-fallback.crt
 
-RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl
+RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl 0.11.1
 
 COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 COPY ceryx.conf /usr/local/openresty/nginx/sites-enabled/ceryx.conf


### PR DESCRIPTION
This saves us from cases where Ceryx cannot issue a certificate because of difference in the agreement document of client / server:

  - https://github.com/GUI/lua-resty-auto-ssl/issues/104
  - https://github.com/GUI/lua-resty-auto-ssl/issues/13#issuecomment-344693430