### PR TITLE
Added (optional) support for Redis authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ configuration options are the following:
   * ``CERYX_SECRET_KEY``: the path of the secret key to use - defaults to None
   * ``CERYX_REDIS_HOST``: the redis host to connect to - defaults to 127.0.0.1
   * ``CERYX_REDIS_PORT``: the redis port to connect to - defaults to 6379
+  * ``CERYX_REDIS_PASSWORD``: the redis password to use - defaults to none
   * ``CERYX_REDIS_PREFIX``: the redis prefix to use in keys - defaults to ceryx
 
 ## Quick Bootstrap

--- a/api/ceryx/db.py
+++ b/api/ceryx/db.py
@@ -27,10 +27,10 @@ class RedisRouter(object):
         settings.
         """
         return RedisRouter(settings.REDIS_HOST, settings.REDIS_PORT,
-                           0, settings.REDIS_PREFIX)
+                           settings.REDIS_PASSWORD, 0, settings.REDIS_PREFIX)
 
-    def __init__(self, host, port, db, prefix):
-        self.client = redis.StrictRedis(host=host, port=port, db=db)
+    def __init__(self, host, port, password, db, prefix):
+        self.client = redis.StrictRedis(host=host, port=port, password=password, db=db)
         self.prefix = prefix
 
     def _prefixed_route_key(self, source):

--- a/api/ceryx/settings.py
+++ b/api/ceryx/settings.py
@@ -19,4 +19,5 @@ if SECRET_KEY:
 
 REDIS_HOST = os.getenv('CERYX_REDIS_HOST', '127.0.0.1')
 REDIS_PORT = int(os.getenv('CERYX_REDIS_PORT', 6379))
+REDIS_PASSWORD = os.getenv('CERYX_REDIS_PASSWORD', None)
 REDIS_PREFIX = os.getenv('CERYX_REDIS_PREFIX', 'ceryx')

--- a/ceryx/nginx.conf
+++ b/ceryx/nginx.conf
@@ -4,6 +4,7 @@ pid /run/nginx.pid;
 
 env CERYX_REDIS_PREFIX;
 env CERYX_REDIS_HOST;
+env CERYX_REDIS_PASSWORD;
 env CERYX_REDIS_PORT;
 env CERYX_FALLBACK;
 
@@ -86,10 +87,13 @@ http {
         if not redis_host then redis_host = "127.0.0.1" end
         local redis_port = os.getenv("CERYX_REDIS_PORT")
         if not redis_port then redis_port = 6379 end
+        local redis_password = os.getenv("CERYX_REDIS_PASSWORD")
+        if not redis_password then redis_password = nil end
         auto_ssl:set("storage_adapter", "resty.auto-ssl.storage_adapters.redis")
         auto_ssl:set("redis", {
             host = redis_host,
-            port = redis_port
+            port = redis_port,
+            auth = redis_password
         })
 
         auto_ssl:init()

--- a/ceryx/nginx/conf/nginx.conf
+++ b/ceryx/nginx/conf/nginx.conf
@@ -72,7 +72,7 @@ http {
             if redis_password then
                 local res, err = red:auth(redis_password)
                 if not res then
-                    ngx.log("Failed to authenticate with redis: ", err)
+                    ngx.log(ngx.ERR, "Failed to authenticate with redis: ", err)
                     return false
                 end
             end

--- a/ceryx/nginx/conf/nginx.conf
+++ b/ceryx/nginx/conf/nginx.conf
@@ -4,6 +4,7 @@ pid /run/nginx.pid;
 
 env CERYX_REDIS_PREFIX;
 env CERYX_REDIS_HOST;
+env CERYX_REDIS_PASSWORD;
 env CERYX_REDIS_PORT;
 env CERYX_FALLBACK;
 
@@ -56,12 +57,24 @@ http {
             if not redis_host then redis_host = "127.0.0.1" end
             local redis_port = os.getenv("CERYX_REDIS_PORT")
             if not redis_port then redis_port = 6379 end
+            local redis_password = os.getenv("CERYX_REDIS_PASSWORD")
+            if not redis_password then redis_password = nil end
+
             local res, err = red:connect(redis_host, redis_port)
 
             -- Return if could not connect to Redis
             if not res then
                 ngx.log(ngx.ERR, "Error connecting to redis: " .. (err or ""))
                 return false
+            end
+
+            -- Authenticate with Redis if necessary
+            if redis_password then
+                local res, err = red:auth(redis_password)
+                if not res then
+                    ngx.log("Failed to authenticate with redis: ", err)
+                    return false
+                end
             end
 
             -- Construct Redis key

--- a/ceryx/nginx/lualib/router.lua
+++ b/ceryx/nginx/lualib/router.lua
@@ -15,11 +15,21 @@ local redis_host = os.getenv("CERYX_REDIS_HOST")
 if not redis_host then redis_host = "127.0.0.1" end
 local redis_port = os.getenv("CERYX_REDIS_PORT")
 if not redis_port then redis_port = 6379 end
+local redis_password = os.getenv("CERYX_REDIS_PASSWORD")
+if not redis_password then redis_password = nil end
 local res, err = red:connect(redis_host, redis_port)
 
 -- Return if could not connect to Redis
 if not res then
     return ngx.exit(ngx.HTTP_BAD_GATEWAY)
+end
+
+if redis_password then
+    local res, err = red:auth(redis_password)
+    if not res then
+        ngx.ERR("Failed to authenticate Redis: ", err)
+        return
+    end
 end
 
 -- Construct Redis key


### PR DESCRIPTION
This adds a new optional `CERYX_REDIS_PASSWORD` environment variable that allows for using Redis instances with password protection.