### PR TITLE
Update `networks` in Compose files to work better with Swarm

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.5'
 
 services:
   ceryx:
@@ -19,3 +19,9 @@ services:
     environment:
       CERYX_API_HOSTNAME: ${CERYX_API_HOSTNAME:-api.ceryx.dev}
       CERYX_DEBUG: ${CERYX_DEBUG:-true}
+
+networks:
+  default:
+    attachable: true
+    driver: bridge  # Use a Bridge network for local development
+    name: ceryx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.5'
 
 services:
   ceryx:
@@ -29,6 +29,12 @@ services:
     image: redis:3.2.11-alpine
     volumes:
       - redis_data:/data
+
+networks:
+  default:
+    attachable: true
+    driver: overlay
+    name: ceryx
 
 volumes:
   redis_data:


### PR DESCRIPTION
This PR introduces the following changes to the Compose files of the repo:

1. Attachable overlay network named `ceryx` for production, that allows easy connection of other services via Docker Swarm
2. Attachable bridge network named `ceryx` for development