### PR TITLE
Upgrade resty auto SSL to latest version and fix certificate deployment crashes

### DIFF
--- a/ceryx/Dockerfile
+++ b/ceryx/Dockerfile
@@ -10,4 +10,4 @@ RUN mkdir -p /etc/letsencrypt &&\
         -keyout /etc/ssl/resty-auto-ssl-fallback.key \
         -out /etc/ssl/resty-auto-ssl-fallback.crt
 
-RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl 0.11.1
+RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl 0.12.0

--- a/ceryx/nginx/conf/ceryx.conf
+++ b/ceryx/nginx/conf/ceryx.conf
@@ -72,6 +72,8 @@ server {
 # Internal server running on port 8999 for handling certificate tasks.
 server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 1m;
+    client_max_body_size 1m;
     location / {
         content_by_lua_block {
             auto_ssl:hook_server()


### PR DESCRIPTION
* Increase client_body_buffer_size to 1m
  Now, even larger certificates can be posted, since support for buffering arguments from disk is not supported in LUA NGINX - openresty/lua-nginx-module#521 - making new certificate generation deployment to crash.
* Upgrade lua-resty-auto-ssl to version 0.12.0
  This fixes issues produced by recent updates in LE, by updating the underlying dehydrated script.
  Release notes: https://github.com/GUI/lua-resty-auto-ssl/releases/tag/v0.12.0