### PR TITLE
Introduce "enforce_https" setting for routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ dev.yml
 data
 docker-compose.yaml
 .stolos
+
+# Ignore Vim files
+*.swp
+*.swo

--- a/api/ceryx/api/views.py
+++ b/api/ceryx/api/views.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from flask import request 
+from flask import request
 from flask.ext.restful import reqparse, abort, Resource, fields, marshal_with
 
 from ceryx.db import RedisRouter

--- a/api/ceryx/api/views.py
+++ b/api/ceryx/api/views.py
@@ -37,10 +37,10 @@ def lookup_or_abort(source):
     """
     try:
         resource = {
-	    'source': source,
-	    'target': router.lookup(source),
-	    'settings': router.lookup_settings(source),
-	}
+            'source': source,
+            'target': router.lookup(source),
+            'settings': router.lookup_settings(source),
+        }
         return resource
     except RedisRouter.LookupNotFound:
         abort(

--- a/api/ceryx/api/views.py
+++ b/api/ceryx/api/views.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from flask import request
+from flask import request 
 from flask.ext.restful import reqparse, abort, Resource, fields, marshal_with
 
 from ceryx.db import RedisRouter
@@ -22,10 +22,16 @@ parser.add_argument(
 parser.add_argument(
     'target', type=str, required=True, help='Target is required'
 )
+parser.add_argument(
+    'settings', type=dict,
+)
 
 update_parser = reqparse.RequestParser()
 update_parser.add_argument(
     'target', type=str, required=True, help='Target is required'
+)
+update_parser.add_argument(
+    'settings', type=dict,
 )
 
 router = RedisRouter.from_config()
@@ -84,7 +90,10 @@ class Route(Resource):
         given target
         """
         args = update_parser.parse_args()
-        router.insert(source, args['target'])
+        args['settings']['enforce_https'] = (
+            1 if args['settings']['enforce_https'] else 0
+        )
+        router.insert(source, **args)
         return args, 201
 
 
@@ -101,7 +110,7 @@ class RoutesList(Resource):
         given target
         """
         args = parser.parse_args()
-        router.insert(args['source'], args['target'])
+        router.insert(**args)
         return args, 201
 
     @marshal_with(resource_fields)

--- a/api/ceryx/db.py
+++ b/api/ceryx/db.py
@@ -22,7 +22,7 @@ def decode_settings(settings):
     Decode and sanitize settings from Redis, in order to transport via HTTP
     """
     decoded = {
-        'enforce_https': bool(int(settings.get('enforce_https', False)))
+        'enforce_https': bool(int(settings.get('enforce_https', '0')))
     }
 
     return decoded

--- a/api/ceryx/db.py
+++ b/api/ceryx/db.py
@@ -5,6 +5,7 @@ import redis
 
 from ceryx import settings
 
+
 class RedisRouter(object):
     """
     Router using a redis backend, in order to route incoming requests.
@@ -13,6 +14,7 @@ class RedisRouter(object):
         """
         Exception raised when a lookup for a specific host was not found.
         """
+
         def __init__(self, message, errors=None):
             Exception.__init__(self, message)
             if errors is None:
@@ -30,7 +32,8 @@ class RedisRouter(object):
                            settings.REDIS_PASSWORD, 0, settings.REDIS_PREFIX)
 
     def __init__(self, host, port, password, db, prefix):
-        self.client = redis.StrictRedis(host=host, port=port, password=password, db=db)
+        self.client = redis.StrictRedis(
+            host=host, port=port, password=password, db=db)
         self.prefix = prefix
 
     def _prefixed_route_key(self, source):
@@ -76,8 +79,8 @@ class RedisRouter(object):
         Fetches the settings of the given host name.
         """
         key = self._prefixed_settings_key(host)
-	settings = self.client.hgetall(key)
-	return settings or {}
+        settings = self.client.hgetall(key)
+        return settings or {}
 
     def lookup_hosts(self, pattern):
         """
@@ -102,7 +105,7 @@ class RedisRouter(object):
                 {
                     'source': host,
                     'target': self.lookup(host, silent=True),
-		    'settings': self.lookup_settings(host),
+                    'settings': self.lookup_settings(host),
                 }
             )
         return routes

--- a/api/ceryx/db.py
+++ b/api/ceryx/db.py
@@ -80,6 +80,10 @@ class RedisRouter(object):
         prefixed_key = prefixed_key % source
         return prefixed_key
     
+    def _delete_settings_for_source(self, source):
+        settings_key = self._prefixed_settings_key(source)
+        self.client.delete(settings_key)
+    
     def _set_settings_for_source(self, source, settings):
         settings_key = self._prefixed_settings_key(source)
 
@@ -87,7 +91,7 @@ class RedisRouter(object):
             encoded_settings = encode_settings(settings)
             self.client.hmset(settings_key, encoded_settings)
         else:
-            self.client.delete(settings_key)
+            self._delete_settings_for_source(source)
 
     def lookup(self, host, silent=False):
         """
@@ -156,3 +160,4 @@ class RedisRouter(object):
         """
         source_key = self._prefixed_route_key(source)
         self.client.delete(source_key)
+        self._delete_settings_for_source(source)

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,13 +1,34 @@
+import json
 import unittest
 
 from flask import json
 
 import ceryx
 
+class CeryxTestingClientProxy(object):
+    def __init__(self, upstream_client):
+        self._upstream = upstream_client
+    
+    def _request(self, method, path, data=None):
+        _method = getattr(self._upstream, method)
+        json_data = json.dumps(data) if data else None
+        return _method(path, data=json_data, content_type='application/json')
+
+    def get(self, path):
+        return self._request('get', path)
+    
+    def post(self, path, data):
+        return self._request('post', path, data=data)
+    
+    def delete(self, path):
+        return self._request('delete', path)
+
+
 class CeryxTestCase(unittest.TestCase):
     def setUp(self):
         ceryx.api.app.testing = True
-        self.app = ceryx.api.app.test_client()
+        testing_client = ceryx.api.app.test_client()
+        self.app = CeryxTestingClientProxy(testing_client)
 
     def test_list_routes(self):
         """
@@ -24,17 +45,88 @@ class CeryxTestCase(unittest.TestCase):
         """
         route_data = {
             'source': 'test.dev',
-            'target': 'localhost:11235'
+            'target': 'localhost:11235',
+        }
+        expected_response = {
+            'source': 'test.dev',
+            'target': 'localhost:11235',
+            'settings': {
+                'enforce_https': False,
+            }
         }
         
         # Create a route and assert valid data in response
         resp = self.app.post('/api/routes', data=route_data)
         self.assertEqual(resp.status_code, 201)
-        self.assertDictEqual(json.loads(resp.data), route_data)
+        self.assertDictEqual(json.loads(resp.data), expected_response)
         
         # Also get the route and assert valid data
         resp = self.app.get('/api/routes/test.dev')
-        self.assertDictEqual(json.loads(resp.data), route_data)
+        self.assertDictEqual(json.loads(resp.data), expected_response)
+
+    def test_enforce_https(self):
+        """
+        Assert that creating a route with the `enforce_https` settings returns
+        the expected results
+        """
+        route_without_enforce_https = {
+            'source': 'test-no-enforce-https.dev',
+            'target': 'localhost:11235',
+        }
+        route_enforce_https_true = {
+            'source': 'test-enforce-https-true.dev',
+            'target': 'localhost:11235',
+            'settings': {
+                'enforce_https': True,
+            },
+        }
+        route_enforce_https_false = {
+            'source': 'test-enforce-https-false.dev',
+            'target': 'localhost:11235',
+            'settings': {
+                'enforce_https': False,
+            },
+        }
+        expected_response_without_enforce_https = {
+            'source': 'test-no-enforce-https.dev',
+            'target': 'localhost:11235',
+            'settings': {
+                'enforce_https': False,
+            },
+        }
+        
+        resp = self.app.post('/api/routes', data=route_without_enforce_https)
+        self.assertEqual(resp.status_code, 201)
+        self.assertDictEqual(
+            json.loads(resp.data), expected_response_without_enforce_https,
+        )
+        
+        resp = self.app.get('/api/routes/test-no-enforce-https.dev')
+        self.assertDictEqual(
+            json.loads(resp.data), expected_response_without_enforce_https,
+        )
+        
+        resp = self.app.post('/api/routes', data=route_enforce_https_true)
+        self.assertEqual(resp.status_code, 201)
+        self.assertDictEqual(
+            json.loads(resp.data), route_enforce_https_true,
+        )
+        
+        resp = self.app.get('/api/routes/test-enforce-https-true.dev')
+        self.assertDictEqual(
+            json.loads(resp.data), route_enforce_https_true,
+        )
+        
+        resp = self.app.post('/api/routes', data=route_enforce_https_false)
+        self.assertEqual(resp.status_code, 201)
+        self.assertDictEqual(
+            json.loads(resp.data), route_enforce_https_false,
+        )
+        
+        resp = self.app.get('/api/routes/test-enforce-https-false.dev')
+        self.assertDictEqual(
+            json.loads(resp.data), route_enforce_https_false,
+        )
 
     def test_delete_route(self):
         """

--- a/ceryx/nginx/lualib/router.lua
+++ b/ceryx/nginx/lualib/router.lua
@@ -30,17 +30,19 @@ if redis_password then
     end
 end
 
-local settings_key = prefix .. ":settings:" .. host
-local enforce_https, flags = cache:get(host .. ":enforce_https")
+if is_not_https then
+    local settings_key = prefix .. ":settings:" .. host
+    local enforce_https, flags = cache:get(host .. ":enforce_https")
 
-if enforce_https == nil then
-    local res, flags = red:hget(settings_key, "enforce_https")
-    enforce_https = tonumber(res)
-    cache:set(host .. ":enforce_https", enforce_https, 5)
-end
+    if enforce_https == nil then
+        local res, flags = red:hget(settings_key, "enforce_https")
+        enforce_https = tonumber(res)
+        cache:set(host .. ":enforce_https", enforce_https, 5)
+    end
 
-if enforce_https and is_not_https then
-    return ngx.redirect("https://" .. host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY)
+    if enforce_https then
+        return ngx.redirect("https://" .. host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY)
+    end
 end
 
 -- Check if key exists in local cache

--- a/ceryx/nginx/lualib/router.lua
+++ b/ceryx/nginx/lualib/router.lua
@@ -54,3 +54,15 @@ end
 cache:set(host, res, 5)
 
 ngx.var.container_url = res
+
+local settings_key = prefix .. ":settings:" .. host
+
+res, err = red:hget(settings_key, "enforce_https")
+
+local enforce_https = tonumber(res)
+local is_not_https = (ngx.var.scheme ~= "https")
+
+if enforce_https and is_not_https then
+    return ngx.redirect("https://" .. host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY)
+end
+

--- a/ceryx/nginx/lualib/router.lua
+++ b/ceryx/nginx/lualib/router.lua
@@ -1,9 +1,22 @@
 local host = ngx.var.host
 local is_not_https = (ngx.var.scheme ~= "https")
+local cache = ngx.shared.ceryx
+
+local settings_key = prefix .. ":settings:" .. host
+local enforce_https, flags = cache:get(host .. ":enforce_https")
+
+if enforce_https == nil then
+    local res, flags = red:hget(settings_key, "enforce_https")
+    enforce_https = tonumber(res)
+    cache:set(host .. ":enforce_https", enforce_https, 5)
+end
+
+if enforce_https and is_not_https then
+    return ngx.redirect("https://" .. host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY)
+end
 
 -- Check if key exists in local cache
-local cache = ngx.shared.ceryx
-local res, flags = cache:get(host)
+res, flags = cache:get(host)
 if res then
     ngx.var.container_url = res
     
@@ -62,16 +75,4 @@ end
 cache:set(host, res, 5)
 
 ngx.var.container_url = res
-
-local settings_key = prefix .. ":settings:" .. host
-
-res, err = red:hget(settings_key, "enforce_https")
-
-local enforce_https = tonumber(res)
-
-cache:set(host .. ":enforce_https", enforce_https, 5)
-
-if enforce_https and is_not_https then
-    return ngx.redirect("https://" .. host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY)
-end
 

--- a/ceryx/nginx/lualib/router.lua
+++ b/ceryx/nginx/lualib/router.lua
@@ -70,4 +70,3 @@ end
 cache:set(host, res, 5)
 
 ngx.var.container_url = res
-

--- a/ceryx/nginx/lualib/router.lua
+++ b/ceryx/nginx/lualib/router.lua
@@ -19,13 +19,6 @@ end
 res, flags = cache:get(host)
 if res then
     ngx.var.container_url = res
-    
-    local enforce_https, flags = cache:get(host .. ":enforce_https")
-
-    if enforce_https and is_not_https then
-        return ngx.redirect("https://" .. host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY)
-    end
-
     return
 end
 

--- a/ceryx/nginx/lualib/router.lua
+++ b/ceryx/nginx/lualib/router.lua
@@ -2,6 +2,9 @@ local host = ngx.var.host
 local is_not_https = (ngx.var.scheme ~= "https")
 local cache = ngx.shared.ceryx
 
+local prefix = os.getenv("CERYX_REDIS_PREFIX")
+if not prefix then prefix = "ceryx" end
+
 local settings_key = prefix .. ":settings:" .. host
 local enforce_https, flags = cache:get(host .. ":enforce_https")
 
@@ -47,8 +50,6 @@ if redis_password then
 end
 
 -- Construct Redis key
-local prefix = os.getenv("CERYX_REDIS_PREFIX")
-if not prefix then prefix = "ceryx" end
 local key = prefix .. ":routes:" .. host
 
 -- Try to get target for host


### PR DESCRIPTION
This PR introduces the `enforce_https` setting for routes.

With this new setting, we can create Ceryx routes that redirect to HTTPS, if accessed via unsafe plain HTTP.

The default value of this settings is `false`, in order to maintain backwards compatibility.

---
## API Documentation

### Request

```http
POST /api/routes 

{
  "source": "my-app.mycompany.com",
  "target": "internal-ip:11235",
  "settings": {
    "enforce_https": true
  }
}
```



### Response

```json
{
  "source": "my-app.mycompany.com",
  "target": "internal-ip:11235",
  "settings": {
    "enforce_https": true
  }
}
```