### PR TITLE
Fix certificate key environment variable in template

### DIFF
--- a/ceryx/nginx/conf/ceryx.conf.tmpl
+++ b/ceryx/nginx/conf/ceryx.conf.tmpl
@@ -15,7 +15,7 @@ server {
     default_type text/html;
 
     ssl_certificate {{ default .Env.CERYX_SSL_CERT "/etc/ssl/resty-auto-ssl-fallback.crt" }};
-    ssl_certificate_key {{ default .Env.CERYX_SSL_CERT "/etc/ssl/resty-auto-ssl-fallback.key" }};
+    ssl_certificate_key {{ default .Env.CERYX_SSL_CERT_KEY "/etc/ssl/resty-auto-ssl-fallback.key" }};
 
     # Disable the LE certificate generation
     {{ if ne (lower (default .Env.CERYX_DISABLE_LETS_ENCRYPT "")) "true" }}


### PR DESCRIPTION
This allows using custom certificates as fallback, which did not work because of the typo before.