### PR TITLE
Implement "redirect" routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ curl -H "Content-Type: application/json" \
      http://ceryx-api-host/api/routes/publicly.accessible.domain
 ```
 
-### HTTPS redirects
+### Enforce HTTPS
 
 You can enforce redirection from HTTP to HTTPS for any host you would like.
 
@@ -116,6 +116,17 @@ curl -H "Content-Type: application/json" \
 ```
 
 The above functionality works in `PUT` update requests as well.
+
+### Redirect to target, instead of proxying
+
+Instead of proxying the request to the targetm you can prompt the client to redirect the request there itself.
+
+```
+curl -H "Content-Type: application/json" \
+     -X POST \
+     -d '{"source":"sourcelair.com","target":"https://www.sourcelair.com", "settings": {"mode": "redirect"}}' \
+     http://ceryx-api-host/api/routes
+```
 
 ## Ceryx web UI
 

--- a/api/ceryx/db.py
+++ b/api/ceryx/db.py
@@ -15,7 +15,8 @@ def encode_settings(settings):
     Encode and sanitize settings in order to be written to Redis.
     """
     encoded_settings = {
-        'enforce_https': str(int(settings.get('enforce_https', False)))
+        'enforce_https': str(int(settings.get('enforce_https', False))),
+        'mode': settings.get('mode', 'proxy'),
     }
 
     return encoded_settings
@@ -32,7 +33,8 @@ def decode_settings(settings):
         _str(k): _str(v) for k, v in settings.items()
     }
     decoded = {
-        'enforce_https': bool(int(_settings.get('enforce_https', '0')))
+        'enforce_https': bool(int(_settings.get('enforce_https', '0'))),
+        'mode': _settings.get('mode', 'proxy'),
     }
 
     return decoded

--- a/api/ceryx/types.py
+++ b/api/ceryx/types.py
@@ -1,26 +1,27 @@
 from apistar import types, validators
 
 
+SETTINGS_VALIDATOR = validators.Object(
+    properties={
+        'enforce_https': validators.Boolean(default=False),
+        'mode': validators.String(
+            default='proxy',
+            enum=['proxy', 'redirect'],
+        ),
+    },
+    default={
+        'enforce_https': False,
+        'mode': 'proxy',
+    },
+)
+
+
 class RouteWithoutSource(types.Type):
     target = validators.String()
-    settings = validators.Object(
-        properties={
-            'enforce_https': validators.Boolean(default=False),
-        },
-        default={
-            'enforce_https': False,
-        },
-    )
+    settings = SETTINGS_VALIDATOR
 
 
 class Route(types.Type):
     source = validators.String()
     target = validators.String()
-    settings = validators.Object(
-        properties={
-            'enforce_https': validators.Boolean(default=False),
-        },
-        default={
-            'enforce_https': False,
-        },
-    )
+    settings = SETTINGS_VALIDATOR

--- a/api/tests.py
+++ b/api/tests.py
@@ -33,6 +33,7 @@ class CeryxTestCase(unittest.TestCase):
             'target': 'localhost:11235',
             'settings': {
                 'enforce_https': False,
+                'mode': 'proxy',
             }
         }
         
@@ -59,6 +60,7 @@ class CeryxTestCase(unittest.TestCase):
             'target': 'localhost:11235',
             'settings': {
                 'enforce_https': True,
+                'mode': 'proxy',
             },
         }
         route_enforce_https_false = {
@@ -66,6 +68,7 @@ class CeryxTestCase(unittest.TestCase):
             'target': 'localhost:11235',
             'settings': {
                 'enforce_https': False,
+                'mode': 'proxy',
             },
         }
         expected_response_without_enforce_https = {
@@ -73,6 +76,7 @@ class CeryxTestCase(unittest.TestCase):
             'target': 'localhost:11235',
             'settings': {
                 'enforce_https': False,
+                'mode': 'proxy',
             },
         }
         
@@ -107,6 +111,65 @@ class CeryxTestCase(unittest.TestCase):
         response = self.client.get('/api/routes/test-enforce-https-false.dev')
         self.assertDictEqual(
             response.json(), route_enforce_https_false,
+        )
+
+    def test_mode(self):
+        """
+        Assert that creating a route with or without the `mode` setting returns
+        the expected results.
+        """
+        route_without_mode = {
+            'source': 'www.my-website.dev',
+            'target': 'localhost:11235',
+        }
+        route_mode_proxy = {
+            'source': 'www.my-website.dev',
+            'target': 'localhost:11235',
+            'settings': {
+                'enforce_https': False,
+                'mode': 'proxy',
+            },
+        }
+        route_mode_redirect = {
+            'source': 'my-website.dev',
+            'target': 'www.my-website.dev',
+            'settings': {
+                'enforce_https': False,
+                'mode': 'redirect',
+            },
+        }
+        
+        response = self.client.post('/api/routes', json=route_without_mode)
+        self.assertEqual(response.status_code, 201)
+        self.assertDictEqual(
+            response.json(), route_mode_proxy,
+        )
+        
+        response = self.client.get('/api/routes/www.my-website.dev')
+        self.assertDictEqual(
+            response.json(), route_mode_proxy,
+        )
+        
+        response = self.client.post('/api/routes', json=route_mode_proxy)
+        self.assertEqual(response.status_code, 201)
+        self.assertDictEqual(
+            response.json(), route_mode_proxy,
+        )
+        
+        response = self.client.get('/api/routes/www.my-website.dev')
+        self.assertDictEqual(
+            response.json(), route_mode_proxy,
+        )
+        
+        response = self.client.post('/api/routes', json=route_mode_redirect)
+        self.assertEqual(response.status_code, 201)
+        self.assertDictEqual(
+            response.json(), route_mode_redirect,
+        )
+        
+        response = self.client.get('/api/routes/my-website.dev')
+        self.assertDictEqual(
+            response.json(), route_mode_redirect,
         )
 
     def test_delete_route(self):

--- a/ceryx/tests/routes.bats
+++ b/ceryx/tests/routes.bats
@@ -18,14 +18,26 @@
   [ $ceryx_status_code -eq $upstream_status_code ]
 }
 
-@test "301 response and appropriate 'Location' header when enforce_https=true" {
+@test "301 response when enforce_https=true" {
   curl -s -o /dev/null \
        -X POST \
        -H 'Content-Type: application/json' \
-       -d '{"source": "enforced-https-route", "target": "somewhere", "settings":{"enforce_https":true}}' \
+       -d '{"source": "enforced-https-route", "target": "somewhere", "settings":{"enforce_https": true}}' \
        http://api:5555/api/routes/
 
   status_code=$(curl -s -o /dev/null -I -w "%{http_code}" -H "Host: enforced-https-route" http://ceryx/)
+
+  [ $status_code -eq 301 ]
+}
+
+@test "301 response when mode=redirect" {
+  curl -s -o /dev/null \
+       -X POST \
+       -H 'Content-Type: application/json' \
+       -d '{"source": "redirected-route", "target": "redirection-target", "settings":{"mode": "redirect"}}' \
+       http://api:5555/api/routes/
+
+  status_code=$(curl -s -o /dev/null -I -w "%{http_code}" -H "Host: redirected-route" http://ceryx/)
 
   [ $status_code -eq 301 ]
 }


### PR DESCRIPTION
This is super useful for registering routes that are intended to redirect, instead of proxy requests.

## Use case

- `www.example.com` proxies to upstream service
- `example.com` redirects to `www.example.com`