### PR TITLE
Add trailing slash

### DIFF
--- a/api/bin/populate-api
+++ b/api/bin/populate-api
@@ -9,4 +9,4 @@ echo "Register the API to Ceryx"
 curl -H "Content-Type: application/json" \
      -X POST \
      -d '{"source":"'$CERYX_API_HOSTNAME'","target":"api:'$CERYX_API_PORT'"}' \
-     http://localhost:$CERYX_API_PORT/api/routes
+     http://localhost:$CERYX_API_PORT/api/routes/


### PR DESCRIPTION
Without this, the ceryx api initiates a redirect instead of actually registering a route. 