### PR TITLE
Make Redis timeout configurable via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Ceryx is configured with the following environment variables:
   - `CERYX_REDIS_PASSWORD`: Optional password to use for authenticating with Redis (default: None)
   - `CERYX_REDIS_PORT`: The where Redis should be reached (default: `6379`)
   - `CERYX_REDIS_PREFIX`: The prefix to use in Ceryx-related Redis keys (default: `ceryx`)
+  - `CERYX_REDIS_TIMEOUT`: The timeout for all Redis operations, including the intial connection to Redis, specified in milliseconds (default: `100`)
   - `CERYX_SSL_DEFAULT_CERTIFICATE`: The path to the fallback SSL certificate (default: `/etc/ceryx/ssl/default.crt` — randomly generated at build time)
   - `CERYX_SSL_DEFAULT_KEY`: The path to the fallback SSL certificate key (default: `/etc/ceryx/ssl/default.key` — randomly generated at build time)
 

--- a/api/ceryx/db.py
+++ b/api/ceryx/db.py
@@ -23,10 +23,11 @@ class RedisClient:
             settings.REDIS_PASSWORD,
             0,
             settings.REDIS_PREFIX,
+            settings.REDIS_TIMEOUT,
         )
 
-    def __init__(self, host, port, password, db, prefix):
-        self.client = redis.StrictRedis(host=host, port=port, password=password, db=db)
+    def __init__(self, host, port, password, db, prefix, timeout):
+        self.client = redis.StrictRedis(host=host, port=port, password=password, db=db, socket_timeout=timeout, socket_connect_timeout=timeout)
         self.prefix = prefix
     
     def _prefixed_key(self, key):

--- a/api/ceryx/settings.py
+++ b/api/ceryx/settings.py
@@ -20,3 +20,4 @@ REDIS_HOST = os.getenv("CERYX_REDIS_HOST", "127.0.0.1")
 REDIS_PORT = int(os.getenv("CERYX_REDIS_PORT", 6379))
 REDIS_PASSWORD = os.getenv("CERYX_REDIS_PASSWORD", None)
 REDIS_PREFIX = os.getenv("CERYX_REDIS_PREFIX", "ceryx")
+REDIS_TIMEOUT = int(os.getenv("CERYX_REDIS_TIMEOUT", 100)) * 0.001 # Python Redis client requires units of seconds

--- a/ceryx/nginx/conf/nginx.conf.tmpl
+++ b/ceryx/nginx/conf/nginx.conf.tmpl
@@ -7,6 +7,7 @@ env CERYX_REDIS_PREFIX;
 env CERYX_REDIS_HOST;
 env CERYX_REDIS_PASSWORD;
 env CERYX_REDIS_PORT;
+env CERYX_REDIS_TIMEOUT;
 
 events {
     worker_connections 1024;

--- a/ceryx/nginx/lualib/ceryx/redis.lua
+++ b/ceryx/nginx/lualib/ceryx/redis.lua
@@ -5,6 +5,7 @@ local prefix = utils.getenv("CERYX_REDIS_PREFIX", "ceryx")
 local host = utils.getenv("CERYX_REDIS_HOST", "127.0.0.1")
 local port = utils.getenv("CERYX_REDIS_PORT", 6379)
 local password = utils.getenv("CERYX_REDIS_PASSWORD", nil)
+local timeout = utils.getenv("CERYX_REDIS_TIMEOUT", 100)  -- 100 ms
 
 local exports = {}
 
@@ -13,7 +14,7 @@ function exports.client()
     ngx.log(ngx.DEBUG, "Preparing Redis client.")
 
     local red = redis:new()
-    red:set_timeout(100) -- 100 ms
+    red:set_timeout(timeout) 
 
     local res, err = red:connect(host, port)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       CERYX_DOCKERIZE_EXTRA_ARGS: -no-overwrite
       CERYX_REDIS_HOST: ${CERYX_REDIS_HOST:-redis}
       CERYX_REDIS_PORT: ${CERYX_REDIS_PORT:-6379}
+      CERYX_REDIS_TIMEOUT: ${CERYX_REDIS_TIMEOUT:-100}
     command:
       - usr/local/openresty/bin/openresty
       - -g
@@ -32,6 +33,7 @@ services:
       CERYX_DEBUG: ${CERYX_DEBUG:-false}
       CERYX_REDIS_HOST: ${CERYX_REDIS_HOST:-redis}
       CERYX_REDIS_PORT: ${CERYX_REDIS_PORT:-6379}
+      CERYX_REDIS_TIMEOUT: ${CERYX_REDIS_TIMEOUT:-100}
       
   redis:
     image: redis:3.2.11-alpine


### PR DESCRIPTION
I suspect that we're occasionally seeing Redis timeouts due to messages in our Ceryx logs like the following which are associated with HTTP 500 responses from Ceryx:

```
[error] 25#25: *41967 lua tcp socket connect timed out
/usr/local/openresty/nginx/lualib/router.lua:5: in function </usr/local/openresty/nginx/lualib/router.lua:1>
```

The line it's referring to is:
```
local redisClient = redis:client()
```

Currently the Redis timeout is hard-coded to 100ms here: https://github.com/sourcelair/ceryx/blob/master/ceryx/nginx/lualib/ceryx/redis.lua#L16

I suspect that we're occasionally seeing new connections hit this limit, so I would like to try increasing it, but unfortunately it isn't currently configurable via Ceryx.  This PR adds a new environment variable called `CERYX_REDIS_TIMEOUT` which can be used to configure this timeout in units of milliseconds.  I applied this setting to the Ceryx API as well, although the units had to be converted to seconds in that case because that's what the Python Redis client expects.