### PR TITLE
Update Lua Resty Auto SSL to latest version

### DIFF
--- a/ceryx/Dockerfile
+++ b/ceryx/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -fSslL https://github.com/jwilder/dockerize/releases/download/${DOCKERI
 
 # Install lua-resty-auto-ssl for dynamically generating certificates from LE
 # https://github.com/GUI/lua-resty-auto-ssl
-RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl 0.12.0 &&\
+RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl 0.13.1 &&\
     mkdir /etc/resty-auto-ssl/ &&\
     chown -R $user:$group /etc/resty-auto-ssl/
 


### PR DESCRIPTION
Fixes issues with new accounts being registered and switched to using V2 API for Let's Encrypt.

[Release notes](https://github.com/GUI/lua-resty-auto-ssl/releases/tag/v0.13.1)