### PR TITLE
Attempt at Helm chart for Kubernetes deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ Just run the following command to run Ceryx in the background:
 docker-compose up -d
 ```
 
+### Running Ceryx in Kubernetes ###
+
+#### Kubernetes Requirements ####
+1. A Kubernetes cluster deployed with a public facing IP. Kubectl, Helm installed on your machine. Tiller installed on the cluster.  
+
+2. At least one domain/subdomain (or even a wildcard A record) resolving to the cluster IP address.  
+
+3. Edit the values file in .k8s/ceryx/values.yaml to suit your deployment needs.
+
+4. 
+```
+cd k8s
+
+helm install --debug --generate-name --values <path to your value file> ./ceryx
+
+Recommend: Add --dry-run to the above before deploying to check generated yaml. 
+
+```
+
 ### Exposing the API to the public
 
 **👋 Heads up!** Don't ever do this in production! Anyone from the internet will be able to access the Ceryx API and mess with it. It's useful for development/testing though.

--- a/k8s/ceryx/.helmignore
+++ b/k8s/ceryx/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/ceryx/Chart.yaml
+++ b/k8s/ceryx/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: ceryx
+description: A Helm chart for ceryx
+type: application
+version: 0.1.0
+appVersion: 1.16.0
+keywords:
+    - ceryx
+sources: 
+    - https://github.com/sourcelair/ceryx

--- a/k8s/ceryx/templates/_helpers.tpl
+++ b/k8s/ceryx/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ceryx.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ceryx.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ceryx.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "ceryx.labels" -}}
+helm.sh/chart: {{ include "ceryx.chart" . }}
+{{ include "ceryx.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ceryx.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ceryx.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ceryx.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "ceryx.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/k8s/ceryx/templates/ceryx-api.yaml
+++ b/k8s/ceryx/templates/ceryx-api.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{default "ceryx-api" .Values.ceryxApi.name }}
+  labels:
+    app: {{default "ceryx-api" .Values.ceryxApi.name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+{{- if .Values.ceryxApi.service.labels -}}
+{{ toYaml .Values.ceryxApi.service.labels | indent 4}}
+{{- end }}
+{{- if .Values.ceryxApi.service.annotations }}
+  annotations:
+{{ toYaml .Values.ceryxApi.annotations | indent 8}}
+{{- end }}
+spec:
+  type: {{default "ClusterIP" .Values.ceryxApi.service.type }}
+  selector:
+    app: {{default "ceryx-api" .Values.ceryxApi.name }}
+  ports:
+  - name: {{default "ceryx-api" .Values.ceryxApi.name }}-http
+    port: {{default 5555 .Values.ceryxApi.containerPort.http }}
+  
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{default "ceryx-api" .Values.ceryxApi.name }}
+  labels:
+    app: {{default "ceryx-api" .Values.ceryxApi.name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{default 1 .Values.ceryxApi.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{default "ceryx-api" .Values.ceryxApi.name }}
+  template:
+    metadata:
+      labels:
+        app: {{default "ceryx-api" .Values.ceryxApi.name }}
+    spec:
+{{- if .Values.ceryxApi.nodeSelector }}
+      nodeSelector: 
+{{ toYaml .Values.ceryxApi.nodeSelector | indent 12}}
+{{- end }}
+      containers:
+      - name: {{default "ceryx-api" .Values.ceryxApi.name }}
+        image: {{ .Values.ceryxApi.image.repository }}:{{default "latest" .Values.ceryxApi.image.tag }}
+        imagePullPolicy: {{default "IfNotPresent" .Values.ceryxApi.image.pullPolicy }}
+        ports:
+        - containerPort: {{default 5555 .Values.ceryxApi.containerPort.http }}
+        #command: ["usr/local/openresty/bin/openresty"]
+        #args: ["-g", "daemon off;"]
+        env:
+        - name: CERYX_DEBUG
+          value: {{default "false" .Values.envvars.CERYX_DEBUG | quote }}
+        - name: CERYX_MAX_REQUEST_BODY_SIZE
+          value: {{default "100m" .Values.envvars.CERYX_MAX_REQUEST_BODY_SIZE | quote }}
+        - name: CERYX_REDIS_HOST
+          value: {{required "Address of host is required." .Values.envvars.CERYX_REDIS_HOST | quote }}
+        - name: CERYX_REDIS_PORT
+          value: {{default 6379 .Values.ceryxRedis.containerPort.redis | quote }}
+        - name: CERYX_REDIS_PREFIX
+          value: {{default "ceryx" .Values.ceryxRedis.containerPort.redis | quote }}
+{{ if (not (empty .Values.ceryxRedis.password)) }}
+        - name: CERYX_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ceryx-redis-secret
+              key: CERYX_REDIS_PASSWORD
+{{end }}
+        - name: CERYX_REDIS_TIMEOUT
+          value: {{default 100 .Values.envvars.CERYX_REDIS_TIMEOUT | quote }}
+        - name: CERYX_DNS_RESOLVER
+          value: {{default "10.0.0.10" .Values.envvars.CERYX_DNS_RESOLVER  | quote }}
+        - name: CERYX_API_HOST
+          value: {{default "0.0.0.0" .Values.envvars.CERYX_API_HOST | quote }}
+        - name: CERYX_API_PORT
+          value: {{default 5555 .Values.ceryxApi.containerPort.http | quote }}
+    

--- a/k8s/ceryx/templates/ceryx-nginx.yaml
+++ b/k8s/ceryx/templates/ceryx-nginx.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{default "ceryx-nginx" .Values.ceryxNginx.name }}
+  labels:
+    app: {{default "ceryx-nginx" .Values.ceryxNginx.name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+{{ if .Values.ceryxNginx.service.labels }}
+{{ toYaml .Values.ceryxNginx.service.labels | indent 4}}
+{{ end }}
+{{ if .Values.ceryxNginx.service.annotations }}
+  annotations:
+{{ toYaml .Values.ceryxNginx.service.annotations | indent 4}}
+{{ end }}
+spec:
+{{ if (and (eq .Values.ceryxNginx.service.type "LoadBalancer") (not (empty .Values.ceryxNginx.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.ceryxNginx.service.loadBalancerIP }}
+{{ end }}
+  type: {{ .Values.ceryxNginx.service.type }}
+  selector:
+    app: {{default "ceryx-nginx" .Values.ceryxNginx.name }}
+  ports:
+    - port: {{default 80 .Values.ceryxNginx.containerPort.http }}
+      targetPort: 80
+      protocol: TCP
+      name: {{default "ceryx-nginx" .Values.ceryxNginx.name }}-http
+    - port: {{default 443 .Values.ceryxNginx.containerPort.https }}
+      targetPort: 443
+      protocol: TCP
+      name: {{default "ceryx-nginx" .Values.ceryxNginx.name }}-https
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{default "ceryx-nginx" .Values.ceryxNginx.name }}
+  labels:
+    app: {{default "ceryx-nginx" .Values.ceryxNginx.name }}
+spec:
+  replicas: {{default 1 .Values.ceryxNginx.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{default "ceryx-nginx" .Values.ceryxNginx.name }}
+  template:
+    metadata:
+      labels:
+        app: {{default "ceryx-nginx" .Values.ceryxNginx.name }}
+    spec:
+{{- if .Values.ceryxNginx.nodeSelector }}
+      nodeSelector: 
+{{ toYaml .Values.ceryxNginx.nodeSelector | indent 8}}
+{{- end }}
+      containers:
+      - name: {{default "ceryx-nginx" .Values.ceryxNginx.name }}
+        image: {{ .Values.ceryxNginx.image.repository}}:{{default "latest" .Values.ceryxNginx.image.tag}}
+        imagePullPolicy: {{default "IfNotPresent" .Values.ceryxNginx.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.ceryxNginx.containerPort.http }}
+        - containerPort: {{ .Values.ceryxNginx.containerPort.https }}
+        env:
+        - name: CERYX_DEBUG
+          value: {{default "false" .Values.envvars.CERYX_DEBUG | quote }}
+        - name: CERYX_MAX_REQUEST_BODY_SIZE
+          value: {{default "100m" .Values.envvars.CERYX_MAX_REQUEST_BODY_SIZE | quote }}
+        - name: CERYX_REDIS_HOST
+          value: {{ .Values.envvars.CERYX_REDIS_HOST | quote }}
+        - name: CERYX_REDIS_PORT
+          value: {{default 6379 .Values.ceryxRedis.containerPort.redis | quote }}
+        - name: CERYX_REDIS_PREFIX
+          value: {{default "ceryx" .Values.ceryxRedis.containerPort.redis | quote }}
+
+{{ if (not (empty .Values.ceryxRedis.password)) }}
+        - name: CERYX_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ceryx-redis-secret
+              key: CERYX_REDIS_PASSWORD
+{{end }}
+        - name: CERYX_REDIS_TIMEOUT
+          value: {{default "100" .Values.envvars.CERYX_REDIS_TIMEOUT | quote }}
+        - name: CERYX_DISABLE_LETS_ENCRYPT
+          value: {{default "false" .Values.envvars.CERYX_DISABLE_LETS_ENCRYPT | quote }}
+        - name: CERYX_SSL_DEFAULT_CERTIFICATE
+          value: {{default "/etc/ceryx/ssl/default.crt" .Values.envvars.CERYX_SSL_DEFAULT_CERTIFICATE }}
+        - name: CERYX_SSL_DEFAULT_KEY
+          value: {{default "/etc/ceryx/ssl/default.key" .Values.envvars.CERYX_SSL_DEFAULT_KEY }}
+        - name: CERYX_DNS_RESOLVER
+          value: {{default "10.0.0.10" .Values.envvars.CERYX_DNS_RESOLVER  | quote }}
+{{ if (and (eq .Values.ceryxNginx.useHTTPSCert true) (not (empty .Values.ceryxNginx.secretName))) }}
+        volumeMounts:
+          - name: certificatesvolume
+            mountPath: {{default "/etc/ceryx/ssl" .Values.ceryxNginx.certMountPath | quote }}
+            readOnly: true
+      volumes:
+        - name: certificatesvolume
+          secret:
+            secretName: {{ .Values.ceryxNginx.secretName }}
+{{ end }}
+

--- a/k8s/ceryx/templates/ceryx-redis.yaml
+++ b/k8s/ceryx/templates/ceryx-redis.yaml
@@ -1,0 +1,87 @@
+{{ if (not (empty .Values.ceryxRedis.password)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ceryx-redis-secret
+  labels:
+    app: {{default "ceryx-redis" .Values.ceryxRedis.name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+type: Opaque
+data:
+  CERYX_REDIS_PASSWORD: {{ .Values.ceryxRedis.password | b64enc }}
+---
+{{end}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ceryx-redis-volume-claim
+  labels:
+    app: {{default "ceryx-redis" .Values.ceryxRedis.name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{default "5Gi" .Values.ceryxRedis.storage }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{default "ceryx-redis" .Values.ceryxRedis.name }}
+  labels:
+    app: {{default "ceryx-redis" .Values.ceryxRedis.name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  ports:
+    - port: {{default 6379 .Values.ceryxRedis.containerPort.redis }}
+      name: ceryx-redis
+  clusterIP: None
+  selector:
+    app: {{default "ceryx-redis" .Values.ceryxRedis.name }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{default "ceryx-redis" .Values.ceryxRedis.name }}
+  labels:
+    app: {{default "ceryx-redis" .Values.ceryxRedis.name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  selector:
+    matchLabels:
+          app: {{default "ceryx-redis" .Values.ceryxRedis.name }}  # has to match .spec.template.metadata.labels
+  serviceName: {{default "ceryx-redis" .Values.ceryxRedis.name }}
+  replicas: {{default 1 .Values.ceryxRedis.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{default "ceryx-redis" .Values.ceryxRedis.name }}  # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: {{default "redis" .Values.ceryxRedis.image.repository }}
+        image: {{default "redis" .Values.ceryxRedis.image.repository }}:{{default "latest" .Values.ceryxRedis.image.tag }}
+        imagePullPolicy: {{default "redis" .Values.ceryxRedis.image.pullPolicy }}
+{{ if (not (empty .Values.ceryxRedis.password)) }}        
+        args: ["--requirepass", "$(CERYX_REDIS_PASSWORD)", "--appendonly", "yes", "--save", "900", "1", "--save", "30", "2"]       
+{{else }}
+        args: ["--appendonly", "yes", "--save", "900", "1", "--save", "30", "2"]      
+{{end}}
+        ports:
+          - containerPort: {{default 6379 .Values.ceryxRedis.containerPort.redis }}
+            name: ceryx-redis
+        env:
+{{ if (not (empty .Values.ceryxRedis.password)) }}
+        - name: CERYX_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ceryx-redis-secret
+              key: CERYX_REDIS_PASSWORD
+{{ end }}
+        volumeMounts:
+          - name: ceryx-redis-volume
+            mountPath: /data
+      volumes:
+        - name: ceryx-redis-volume
+          persistentVolumeClaim:
+            claimName: ceryx-redis-volume-claim 

--- a/k8s/ceryx/values.yaml
+++ b/k8s/ceryx/values.yaml
@@ -1,0 +1,77 @@
+# Default values for ceryx.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+ceryxNginx:
+  name: "ceryx-nginx"
+  replicaCount: 1
+  nodeSelector: { beta.kubernetes.io/os: linux }
+  image: 
+    repository: "sourcelair/ceryx"
+    tag: "latest"
+    pullPolicy: "IfNotPresent"
+  containerPort:
+    http: 80
+    https: 443
+  #true if you want to mount a cert and key as a secret.
+  useHTTPSCert: true
+  secretName: "your-cert-secret-name"
+  certMountPath: "/etc/ceryx/ssl"
+  service:
+    labels: {}
+    annotations: {}
+    loadBalancerIP:
+    #Only checked implementation on LoadBalancer.
+    type: "LoadBalancer"
+
+ceryxApi:
+  name: "ceryx-api"
+  replicaCount: 1
+  nodeSelector: { beta.kubernetes.io/os: linux }
+  image:
+    repository: "sourcelair/ceryx-api"
+    tag: "latest"
+    pullPolicy: "IfNotPresent"
+  containerPort:
+    http: 5555
+  service:
+    type: "ClusterIP"
+
+ceryxRedis:
+  name: "ceryx-redis"
+  replicaCount: 1
+  image:
+    repository: "redis"
+    tag: "3.2.11-alpine"
+    pullPolicy: "IfNotPresent"
+  containerPort: 
+    redis: 6379
+  #If not specified, then no password assumed.
+  #TODO: Password shouldn't be in values file.  
+  password: 
+  #Size of persistent volume housing redis database on disk. Default: 5Gi
+  storage: "5Gi"
+
+
+envvars:
+  #Default: 0.0.0.0
+  CERYX_API_HOST: "0.0.0.0"
+  #Default: false
+  CERYX_DEBUG: "false"
+  # Default: 10.0.0.10 . May need to change in your cluster. 
+  CERYX_DNS_RESOLVER: "10.0.0.10"
+  #Default: 100m
+  CERYX_MAX_REQUEST_BODY_SIZE: "100m"
+  # DNS Address of Redis Host. May need to change. 
+  CERYX_REDIS_HOST: "ceryx-redis.default.svc.cluster.local"
+  #Default: ceryx
+  CERYX_REDIS_PREFIX: "ceryx"
+  #Default: 100
+  CERYX_REDIS_TIMEOUT: 100
+  #Default: "true". Recommend cert manager for LE in Kubernetes
+  #https://github.com/jetstack/cert-manager
+  CERYX_DISABLE_LETS_ENCRYPT: "true"
+  # If cert/key is mounted via a secret, you may change the below to match. 
+  CERYX_SSL_DEFAULT_CERTIFICATE: "/etc/ceryx/ssl/tls.crt"
+  CERYX_SSL_DEFAULT_KEY: "/etc/ceryx/ssl/tls.key"
+


### PR DESCRIPTION
Opening a PR for this Helm chart for deploying Ceryx in Kubernetes clusters.

I've tested it out in AKS and it works well. Definitely some work to be done around password for redis database. I had it in values.yaml - not ideal. May also try and improve the documentation at a later date also, but I thought it would be best to submit PR and get the ball rolling anyway. 

Thanks,
J